### PR TITLE
Feature/add update version workflow

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,48 @@
+name: Update Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version (must follow semantic versioning and start with 'v')
+        required: false
+        type: string
+      recreate:
+        description: Recreate Tag
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: Dry Run
+        required: false
+        default: false
+        type: boolean
+
+env:
+  TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Fetch Tags
+      if: ${{ inputs.version == '' && inputs.recreate == false }}
+      run: git fetch --tags
+
+    - name: Update Version
+      if: ${{ inputs.version != '' || inputs.recreate == true }}
+      run: |
+        args=""
+        if [ -n "${{ inputs.version }}" ]; then
+          args="$args -v ${{ inputs.version }}"
+        fi
+        if [ "${{ inputs.recreate }}" = "true" ]; then
+          args="$args -r"
+        fi
+        if [ "${{ inputs.dry_run }}" = "true" ]; then
+          args="$args -n"
+        fi
+        bash .github/scripts/update_version.sh $args

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,11 +47,11 @@ GitHubでソースコードを管理する場合、さらに以下の作業が�
 2. GitHubのSecretsに`TEST_PYPI_TOKEN`と`PYPI_TOKEN`を登録します。
 3. GitHub > Setting > Actions > General > Workflow Permissionでread and write permissionsを選択
 
-### `python-check.yaml`
+### python-check.yaml
 - `.py`ファイルに対して、LintとFormatを実施します。
 - `main`ブランチへのプルリクエストをトリガーとします。
 
-### `publish-to-testpypi.yaml`
+### publish-to-testpypi.yaml
 - バージョン更新とTestPyPIへの公開を行います。
 - GitHub Actionsから手動で実行します。
 - 実行時に以下のオプションを指定できます（すべて任意）:
@@ -62,6 +62,9 @@ GitHubでソースコードを管理する場合、さらに以下の作業が�
 ### publish-to-pypi.yaml
 このファイルは、バージョンを更新し、PyPIにパッケージを公開するためのものです。  
 実行方法や指定可能なオプションは、`publish-to-testpypi.yaml`と同じです。
+
+### update-version.yaml
+- このワークフローは、バージョンを更新するためのものです。GitHubに指定したタグをプッシュします。これは、publish-to-testpypi.yamlからTestPYPIへの公開処理を除いたものです。
 
 ## ローカルでの実行
 ### 環境構築

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This approach avoids the dual management of versions in `pyproject.toml` and Git
 ### Preparation
 1. Upload the `.github` directory and its contents to the repository.
 2. Register `TEST_PYPI_TOKEN` and `PYPI_TOKEN` in GitHub Secrets.
+3. Select `read and write permissions` in GitHub > Settings > Actions > General > Workflow Permissions
 
 ### `python-check.yaml`
 - Perform Lint and Format on `.py` files.
@@ -61,6 +62,9 @@ This approach avoids the dual management of versions in `pyproject.toml` and Git
 ### publish-to-pypi.yaml
 This file is for updating the version and publishing the package to PyPI.  
 The execution method and options that can be specified are the same as `publish-to-testpypi.yaml`.
+
+### update-version.yaml
+- This is a workflow for updating versions. It pushes the specified tag to GitHub. It is the same as publish-to-testpypi.yaml but without the publish process.
 
 ## Local Execution
 ### Environment Setup


### PR DESCRIPTION
update-versionのみを実行するワークフローの追加。バージョン更新はしないが、タグの最新化だけしておきたくなることなどがあったりするため。