### PR TITLE
docs生成時にproject名が置換されない問題の解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /docs/source/*
 !/docs/source/index.rst
 !/docs/source/conf.py
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,10 @@ version = get_version()
 release = version
 language = "ja"
 
+# これがないとprojectがドキュメントに表示（置換）されない
+rst_epilog = f"""
+.. |project| replace:: {project}
+"""
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "version-update-workflow-sample"
-version = "0.0.5.dev2+g73d89a3.d20250327"
+version = "0.0.6.dev3+gb8fc588.d20250327"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
sphinxのdocs生成時にproject名が置換されず`|project|`のままになっていた。
原因は不明だが、sphinxの仕様が変わったのかも。
conf.pyに以下を書くとなおった。

```python
rst_epilog = f"""
.. |project| replace:: {project}
"""
```